### PR TITLE
Fix Alignment of Price Range and Search Bar

### DIFF
--- a/Frontend/src/Component/Ayumedical/Ayumedical.tsx
+++ b/Frontend/src/Component/Ayumedical/Ayumedical.tsx
@@ -133,7 +133,7 @@ const Ayumedical = () => {
 
         {/* Search and Filters Section */}
         <div className="mb-8 bg-white rounded-lg shadow-md p-4">
-          <div className="flex flex-col md:flex-row gap-4">
+          <div className="flex flex-col md:flex-row md:items-center gap-4">
             {/* Search Bar with Suggestions */}
             <div className="flex-1 relative">
               <div className="relative">
@@ -173,8 +173,8 @@ const Ayumedical = () => {
             </div>
 
             {/* Price Range Filter */}
-            <div className="md:w-1/3 flex flex-col">
-              <label className="mb-2 font-medium text-green-800">Price Range</label>
+            <div className="md:w-1/3">
+              <label className=" block mb-2 font-medium text-green-800">Price Range</label>
               <div className="flex items-center gap-2">
                 <div className="flex items-center border border-green-300 rounded p-2 w-1/2">
                   <span className="text-green-700 mr-1">₹</span>


### PR DESCRIPTION
### Description
The search bar and price range filter on the Ayurveda Products page were not properly aligned, causing layout inconsistency and uneven gaps.

### Before:
<img width="1901" height="666" alt="image" src="https://github.com/user-attachments/assets/890a6028-6812-4ce8-88e6-7884b8a93bbd" />

### After:
<img width="1783" height="788" alt="image" src="https://github.com/user-attachments/assets/f908329c-f97a-4190-ba5b-32aaf2f8f0a8" />


### Changes Made
- Wrapped both elements in a flex container with proper alignment (`md:items-center`).
- Adjusted spacing and margins for balanced gaps.
- Ensured responsive behavior across desktop, tablet, and mobile.

### Expected Outcome
- Search bar and price range filter are now vertically centered in the same row.
- Layout looks visually consistent and polished on all screen sizes.