### PR TITLE
feat: integrate scroll-to-bottom with scroll-to-top button

### DIFF
--- a/Frontend/src/Component/ScrollToTopButton.tsx
+++ b/Frontend/src/Component/ScrollToTopButton.tsx
@@ -1,32 +1,43 @@
 import React, { useState, useEffect } from "react";
 
-const ScrollToTopButton: React.FC = () => {
-  const [visible, setVisible] = useState<boolean>(true);
+const ScrollButton: React.FC = () => {
+  const [showTop, setShowTop] = useState(false); // false = ↓ by default
 
   useEffect(() => {
-    console.log("ScrollToTopButton mounted ✅");
+    const toggleButton = () => {
+      const scrollTop = document.documentElement.scrollTop;
+      const scrollHeight = document.documentElement.scrollHeight;
+      const clientHeight = document.documentElement.clientHeight;
 
-    const toggleVisible = () => {
-      const scrolled = document.documentElement.scrollTop;
-      console.log("Scrolled:", scrolled);
-      setVisible(scrolled > 50);
+      const halfway = (scrollHeight - clientHeight) / 2;
+
+      // If scrolled past halfway → show top button
+      if (scrollTop > halfway) {
+        setShowTop(true);
+      } else {
+        setShowTop(false);
+      }
     };
 
-    window.addEventListener("scroll", toggleVisible);
-    return () => window.removeEventListener("scroll", toggleVisible);
+    window.addEventListener("scroll", toggleButton);
+    toggleButton(); // run once on mount
+    return () => window.removeEventListener("scroll", toggleButton);
   }, []);
 
   const scrollToTop = () => {
     window.scrollTo({ top: 0, behavior: "smooth" });
   };
 
+  const scrollToBottom = () => {
+    window.scrollTo({ top: document.documentElement.scrollHeight, behavior: "smooth" });
+  };
+
   return (
     <button
-      onClick={scrollToTop}
-        onMouseEnter={e => (e.currentTarget.style.transform = "scale(1.2)")}
-        onMouseLeave={e => (e.currentTarget.style.transform = "scale(1)")}
+      onClick={showTop ? scrollToTop : scrollToBottom}
+      onMouseEnter={(e) => (e.currentTarget.style.transform = "scale(1.2)")}
+      onMouseLeave={(e) => (e.currentTarget.style.transform = "scale(1)")}
       style={{
-        display: visible ? "inline" : "inline",
         position: "fixed",
         bottom: "120px",
         right: "48px",
@@ -36,19 +47,19 @@ const ScrollToTopButton: React.FC = () => {
         borderRadius: "50%",
         width: "50px",
         height: "50px",
-        fontSize: "33px",
+        fontSize: "28px",
         fontWeight: "bold",
         cursor: "pointer",
         boxShadow: "0 2px 6px rgba(0,0,0,0.3)",
         zIndex: 99999,
         transition: "transform 0.2s",
       }}
-      title="Go to top"
-      aria-label="Scroll to top"
+      title={showTop ? "Go to top" : "Go to bottom"}
+      aria-label={showTop ? "Scroll to top" : "Scroll to bottom"}
     >
-      ↑
+      {showTop ? "↑" : "↓"}
     </button>
   );
 };
 
-export default ScrollToTopButton;
+export default ScrollButton;


### PR DESCRIPTION
This PR addresses issue #38 

## Description
This PR integrates a scroll-to-bottom action into the existing scroll-to-top button.  
Now, the button dynamically switches based on the user's scroll position:  

- When the user is in the *top half* of the page → button shows *↓* (scroll down).  
- When the user is in the *bottom half* of the page → button shows *↑* (scroll up).  

This provides a smoother and more intuitive navigation experience.  

---

##  Changes Made
- Button toggles between *scroll-to-top* and *scroll-to-bottom*.  
- Updated ScrollButton component to calculate halfway point of the page.  
- Added smooth scroll behavior for both directions.  

---

## Preview
### Before :
<img width="311" height="160" alt="image" src="https://github.com/user-attachments/assets/b1343cbd-8bf1-42bc-b52b-c1990a272ed1" />

---

### After (when at top)
<img width="250" height="150" alt="image" src="https://github.com/user-attachments/assets/c6e28ea1-dc99-48ad-92d7-13c3c0ed9b8c" />

When at bottom
<img width="245" height="152" alt="image" src="https://github.com/user-attachments/assets/b655164c-45f6-4cee-91db-b9acc29d28e6" />

